### PR TITLE
[Fix] Add CMAKE_Fortran_COMPILER for flang

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /build-flang/flang
 
 WORKDIR /build-flang/flang/build
 RUN cmake .. -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_INSTALL_PREFIX=/usr/local/ \
-    -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
+    -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_Fortran_COMPILER=flang
 RUN make -j$(nproc)
 RUN make install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,4 @@ RUN rm -rf /build-flang
 # ------------------------- Clean up ------------------------------
 
 ### Remove initial build packages
-RUN apt-get autoremove build-essential cmake
+RUN apt-get autoremove -y build-essential cmake


### PR DESCRIPTION
Building flang requires a known Fortran compiler.